### PR TITLE
[19] Implement iframes and knockback on hurt

### DIFF
--- a/Assets/Prefabs/Players/Player.prefab
+++ b/Assets/Prefabs/Players/Player.prefab
@@ -460,6 +460,7 @@ MonoBehaviour:
   wallJumpLockoutTime: 0
   combatCooldown: 5
   flowDrainRate: 10
+  hurtInvulnerabilityTime: 1
   weapons:
   - {fileID: 8474927021672394680}
   - {fileID: 1016169061012764450}

--- a/Assets/Scripts/Enemies/Armadillo/Armadillo.cs
+++ b/Assets/Scripts/Enemies/Armadillo/Armadillo.cs
@@ -38,7 +38,8 @@ namespace Enemies.Armadillo {
         public void Attack(GameObject it) {
             Player targetPlayer = it.GetComponent<Player>();
             if (targetPlayer != null) {
-                targetPlayer.Hurt(attack);
+                var knockback = new Vector2(facing.x * 10, 5); // demo values
+                targetPlayer.Hurt(attack, knockback, 1);
             }
         }
 

--- a/Assets/Scripts/Enemies/Armadillo/Armadillo.cs
+++ b/Assets/Scripts/Enemies/Armadillo/Armadillo.cs
@@ -38,7 +38,11 @@ namespace Enemies.Armadillo {
         public void Attack(GameObject it) {
             Player targetPlayer = it.GetComponent<Player>();
             if (targetPlayer != null) {
-                var knockback = new Vector2(facing.x * 10, 5); // demo values
+                float radians = knockbackAngle * Mathf.Deg2Rad;
+                Vector2 knockback = new Vector2(Mathf.Cos(radians), Mathf.Sin(radians)) * knockbackForce;
+
+                knockback.x *= Mathf.Sign(facing.x);
+
                 targetPlayer.Hurt(attack, knockback, 1);
             }
         }

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -11,6 +11,8 @@ namespace Enemies {
         [SerializeField] internal float maximumHealth;
         [SerializeField] internal float currentHealth;
         [SerializeField] internal float attack;
+        [SerializeField] internal float knockbackForce = 10f;
+        [SerializeField] internal float knockbackAngle = 45f;
 
         public virtual void Start() {
             currentHealth = maximumHealth;

--- a/Assets/Scripts/Enemies/Sundew/Sundew.cs
+++ b/Assets/Scripts/Enemies/Sundew/Sundew.cs
@@ -79,7 +79,14 @@ namespace Enemies.Sundew {
         }
 
         private void Attack(Player it) {
-            it.Hurt(attack);
+            float direction = Mathf.Sign(it.transform.position.x - transform.position.x);
+
+            float radians = knockbackAngle * Mathf.Deg2Rad;
+            Vector2 knockback = new Vector2(Mathf.Cos(radians), Mathf.Sin(radians)) * knockbackForce;
+
+            knockback.x *= direction;
+
+            it.Hurt(attack, knockback, 1);
         }
 
         private void FireProjectile(Vector2 velocity) {

--- a/Assets/Scripts/Players/Player.cs
+++ b/Assets/Scripts/Players/Player.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using Omnia.Utils;
 using Players.Behaviour;
 using UI;
@@ -34,7 +35,7 @@ namespace Players {
         [SerializeField] internal float wallJumpLockoutTime;
         [SerializeField] internal float combatCooldown;
         [SerializeField] internal float flowDrainRate;
-
+        [SerializeField] internal float hurtInvulnerabilityTime;
 
         [SerializeField] internal WeaponClass[] weapons;
         [SerializeField] internal int selectedWeapon;
@@ -66,6 +67,8 @@ namespace Players {
 
         private float currentLockout;
         private float maximumLockout;
+        private float currentHurtInvulnerability;
+
         private CountdownTimer combatTimer;
         private CountdownTimer rollCooldownTimer;
 
@@ -103,7 +106,7 @@ namespace Players {
             UpdateRollCooldownTimer();
 
             sprite.flipX = facing.x == 0 ? sprite.flipX : facing.x < 0;
-
+            currentHurtInvulnerability = Mathf.Max(0, currentHurtInvulnerability - Time.deltaTime);
         }
 
         public void FixedUpdate() {
@@ -124,12 +127,16 @@ namespace Players {
 
         // ***** Methods for handling player stats (HP, Flow) ***** //
 
-        public void Hurt(float damage) {
-            if (invulnerable) return;
+        public void Hurt(float damage, Vector2 velocity = default, float lockout = 0) {
+            if (invulnerable || currentHurtInvulnerability > 0) return;
 
             combatTimer.Start();
             currentHealth = Mathf.Clamp(currentHealth - damage, 0, maximumHealth);
             UIController.Instance.UpdatePlayerHealth(currentHealth, maximumHealth);
+
+            currentHurtInvulnerability = hurtInvulnerabilityTime;
+            UseExternalVelocity(velocity, lockout);
+            StartCoroutine(DoHurtInvincibilityFlicker());
 
             if (currentHealth == 0) Die();
         }
@@ -250,6 +257,17 @@ namespace Players {
 
             if (!rollCooldownTimer.IsRunning) {
                 canRoll = true;
+            }
+        }
+
+        /* This is kind of lazy but it works. */
+        private IEnumerator DoHurtInvincibilityFlicker() {
+            while (currentHurtInvulnerability > 0) {
+                sprite.enabled = false;
+                yield return new WaitForSeconds(0.02f);
+
+                sprite.enabled = true;
+                yield return new WaitForSeconds(0.10f);
             }
         }
     }


### PR DESCRIPTION
Maybe we should give the enemy full control over knockback direction/strength.

Can't reuse `bool invulnerable` property in `Player` for i-frames because roll invulnerability and hurt invulnerability can be active simultaneously and rolling shouldn't cancel current i-frames.