### PR TITLE
[20] Implement buff system

### DIFF
--- a/Assets/Prefabs/Buffs.meta
+++ b/Assets/Prefabs/Buffs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0085b5bcf5e3392458327ca65fbc796a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Buffs/Courage.prefab
+++ b/Assets/Prefabs/Buffs/Courage.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3656856862150354410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1752756167390269384}
+  - component: {fileID: 5999075761924703401}
+  m_Layer: 0
+  m_Name: Courage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1752756167390269384
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3656856862150354410}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5999075761924703401
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3656856862150354410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 321a47adf8becc747ba95194413894a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageReductionPercentage: 0.5

--- a/Assets/Prefabs/Buffs/Courage.prefab.meta
+++ b/Assets/Prefabs/Buffs/Courage.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f156dd0d98bf50a46a65dec5ca4ae240
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Players/Player.prefab
+++ b/Assets/Prefabs/Players/Player.prefab
@@ -294,6 +294,37 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &3705142360075577281
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9209025776175109295}
+  m_Layer: 7
+  m_Name: Buffs
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9209025776175109295
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3705142360075577281}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2157272981753954215}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4303459350338233119
 GameObject:
   m_ObjectHideFlags: 0
@@ -412,6 +443,7 @@ Transform:
   - {fileID: 7919231695536354884}
   - {fileID: 1766989497329719528}
   - {fileID: 898355057700889153}
+  - {fileID: 9209025776175109295}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6725967550211918722
@@ -480,6 +512,7 @@ MonoBehaviour:
   slide: {x: 0, y: 0}
   debugBehaviour: 
   debugPullToTargetTransform: {fileID: 0}
+  buffsParent: {fileID: 9209025776175109295}
 --- !u!50 &1006114366540754684
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -213,6 +213,152 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7343341171840520290}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &485530546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 485530549}
+  - component: {fileID: 485530548}
+  - component: {fileID: 485530547}
+  - component: {fileID: 485530550}
+  m_Layer: 0
+  m_Name: Debug Buff Provider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &485530547
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 485530546}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &485530548
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 485530546}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &485530549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 485530546}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6.504, y: -0.499, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &485530550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 485530546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4681bd330786cca4eb6726f4ecc48885, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  buff: {fileID: 5999075761924703401, guid: f156dd0d98bf50a46a65dec5ca4ae240, type: 3}
+  player: {fileID: 1317116859}
+  buffDuration: 20
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -889,6 +1035,8 @@ MonoBehaviour:
   - {fileID: 1631646899124418994, guid: 2d2d8564f9485fa4c94d7312e0c528b4, type: 3}
   - {fileID: 7157472551080849247, guid: e529af90261235d498ad6837df8c7173, type: 3}
   canvas: {fileID: 1294524348}
+  defaultHealthColor: {r: 1, g: 0, b: 0, a: 1}
+  buffHealthColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
 --- !u!224 &1294524347
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3245,3 +3393,4 @@ SceneRoots:
   - {fileID: 1320361156}
   - {fileID: 970156644}
   - {fileID: 1294524347}
+  - {fileID: 485530549}

--- a/Assets/Scripts/Players/Buff.meta
+++ b/Assets/Scripts/Players/Buff.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b617ed5ac797f7a4bbcb6e92eb093c08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Players/Buff/Buff.cs
+++ b/Assets/Scripts/Players/Buff/Buff.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+// Buffs must be attached to GameObject such that they can have their own particle effects
+// and side effects. Buffs can only apply to the player, as per the current spec
+namespace Players.Buff {
+    public abstract class Buff : MonoBehaviour {
+        protected Player player; // In case we want access to some specific property of the player
+
+        // ***** Event system that buffs can attach to ***** //
+        // PERF: Delegates might be more optimal, but from what I've seen they're a lot less readable
+        // PERF: There may be something faster than a LinkedList, perhaps a HashSet?
+
+        // When the player takes damage, how should we modify the incoming damage?
+        public static LinkedList<Func<float, float>> OnDamageTaken = new LinkedList<Func<float, float>>();
+
+        protected virtual void Start() {
+            if (player == null) Debug.LogWarning($"Player is not set for buff: {name}");
+        }
+
+        public virtual void Initialize(Player p) {
+            player = p;
+        }
+
+        // Responsible for appending `this` to any events
+        public abstract void ApplyBuff();
+        public abstract void RevokeBuff();
+    }
+}

--- a/Assets/Scripts/Players/Buff/Buff.cs.meta
+++ b/Assets/Scripts/Players/Buff/Buff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10b95783d65783e42b8af4cc487d2244
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Players/Buff/Courage.cs
+++ b/Assets/Scripts/Players/Buff/Courage.cs
@@ -1,0 +1,28 @@
+using UI;
+using UnityEngine;
+
+namespace Players.Buff {
+    public class Courage : Buff {
+        [SerializeField] private float damageReductionPercentage;
+
+        protected override void Start() {
+            base.Start();
+        }
+
+        private float ReduceDamage(float incomingDamage) {
+            float outDamage = incomingDamage * damageReductionPercentage;
+            Debug.Log($"{name}: Reducing incoming damage {incomingDamage} to {outDamage}", gameObject);
+            return outDamage;
+        }
+
+        public override void ApplyBuff() {
+            Buff.OnDamageTaken.AddLast(ReduceDamage);
+            UIController.Instance.SetHealthBarColor(UIController.Instance.buffHealthColor);
+        }
+
+        public override void RevokeBuff() {
+            Buff.OnDamageTaken.Remove(ReduceDamage);
+            UIController.Instance.SetHealthBarColor(UIController.Instance.defaultHealthColor);
+        }
+    }
+}

--- a/Assets/Scripts/Players/Buff/Courage.cs.meta
+++ b/Assets/Scripts/Players/Buff/Courage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 321a47adf8becc747ba95194413894a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Players/Buff/DebugBuffProvider.cs
+++ b/Assets/Scripts/Players/Buff/DebugBuffProvider.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Players.Buff {
+// ***** Can instantiate an instance of a Buff onto the Player for debug purposes ***** //
+    public class DebugBuffProvider : MonoBehaviour {
+        [SerializeField] private Buff buff;
+        [SerializeField] private Player player;
+
+        // Solely for debugging buff.RevokeBuff(). If buffs have durations, they should be implemented in the buff itself.
+        [SerializeField] private int buffDuration = -1;
+
+        private Buff buffInstance;
+
+        private void InstantiateBuff() {
+            buffInstance = Instantiate(buff, player.transform);
+            buffInstance.Initialize(player);
+            buffInstance.ApplyBuff();
+
+            if (buffDuration != -1) {
+                Debug.Log($"Buff {buffInstance.name} will end in {buffDuration}");
+                StartCoroutine(DisableBuff());
+            }
+        }
+
+        private IEnumerator DisableBuff() {
+            yield return new WaitForSeconds(buffDuration);
+            buffInstance.RevokeBuff();
+            Debug.Log($"Buff {buffInstance.name} has been revoked", gameObject);
+        }
+
+        public void OnTriggerEnter2D(Collider2D other) {
+            if (other != player.GetComponent<Collider2D>()) return;
+            Debug.Log($"Player entered debug buff provider, instantiating: {buff.name}");
+            InstantiateBuff();
+
+            // Hide this
+            GetComponent<SpriteRenderer>().enabled = false;
+            GetComponent<Collider2D>().enabled = false;
+        }
+    }
+}

--- a/Assets/Scripts/Players/Buff/DebugBuffProvider.cs
+++ b/Assets/Scripts/Players/Buff/DebugBuffProvider.cs
@@ -15,7 +15,7 @@ namespace Players.Buff {
         private Buff buffInstance;
 
         private void InstantiateBuff() {
-            buffInstance = Instantiate(buff, player.transform);
+            buffInstance = Instantiate(buff, player.buffsParent);
             buffInstance.Initialize(player);
             buffInstance.ApplyBuff();
 

--- a/Assets/Scripts/Players/Buff/DebugBuffProvider.cs.meta
+++ b/Assets/Scripts/Players/Buff/DebugBuffProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4681bd330786cca4eb6726f4ecc48885
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Players/Player.cs
+++ b/Assets/Scripts/Players/Player.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Omnia.Utils;
 using Players.Behaviour;
 using UI;
@@ -129,6 +130,11 @@ namespace Players {
 
         public void Hurt(float damage, Vector2 velocity = default, float lockout = 0) {
             if (invulnerable || currentHurtInvulnerability > 0) return;
+
+            // Apply any buffs that reduce incoming damage
+            foreach (var modifier in Buff.Buff.OnDamageTaken) {
+                damage = modifier(damage);
+            }
 
             combatTimer.Start();
             currentHealth = Mathf.Clamp(currentHealth - damage, 0, maximumHealth);

--- a/Assets/Scripts/Players/Player.cs
+++ b/Assets/Scripts/Players/Player.cs
@@ -60,6 +60,8 @@ namespace Players {
         [SerializeField] internal string debugBehaviour;
         [SerializeField] internal Transform debugPullToTargetTransform;
 
+        [SerializeField] internal Transform buffsParent;
+
         // Describes the ratio at which flow is converted into HP.
         public const float FLOW_TO_HP_RATIO = 0.2f;
 

--- a/Assets/Scripts/UI/Bars/HealthBar.cs
+++ b/Assets/Scripts/UI/Bars/HealthBar.cs
@@ -7,5 +7,10 @@ public class HealthBar : MonoBehaviour {
     public void UpdateBar(float current, float max) {
         slider.value = current / max;
     }
+
+    // Temporary for Courage buff
+    public void SetColor(Color c) {
+        slider.fillRect.GetComponent<Image>().color = c;
+    }
 }
 

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Cinemachine;
 using Enemies;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace UI {
     public class UIController : MonoBehaviour {
@@ -9,6 +10,9 @@ namespace UI {
 
         [SerializeField] internal GameObject[] prefabs; // 0: EnemyUI, 1: PlayerHealthBar, 2: PlayerFlowBar
         [SerializeField] internal Canvas canvas;
+        // Used for setting the color of the player's health bar (likely temporary)
+        [SerializeField] internal Color defaultHealthColor = Color.red;
+        [SerializeField] internal Color buffHealthColor = Color.yellow;
 
         private Dictionary<Enemy, EnemyUI> enemies;
         private PlayerUI playerUI;
@@ -60,6 +64,10 @@ namespace UI {
 
         public void UpdatePlayerFlow(float current, float max) {
             playerUI.FlowBar.UpdateBar(current, max);
+        }
+
+        public void SetHealthBarColor(Color c) {
+            playerUI.HealthBar.SetColor(c);
         }
     }
 


### PR DESCRIPTION
Completed:
- Implement abstract Buff class according to spec
- Add event system that Buffs can attach to such that they can modify values. See Buff.cs, Courage.cs, and Player.cs to see how damage reduction is implemented

Marking this as a draft as I think some things can still be improved on. Primarily, how I utilise a LinkedList<Func<...,...>> to handle different events instead of using a more C#-esque delegate system:
```cs
// Buff.cs
// When the player takes damage, how should we modify the incoming damage?
public static LinkedList<Func<float, float>> OnDamageTaken = new LinkedList<Func<float, float>>();

// Player.cs
public void Hurt(float damage, Vector2 velocity = default, float lockout = 0) {
    foreach (var modifier in Buff.Buff.OnDamageTaken) {
        damage = modifier(damage);
    }
}
```

 I was looking at how I could use delegates to modify a value, and I didn't like what I saw:

While it would be cleaner to append events, ie:
```cs
Buff.OnDamageTaken += ReduceDamage;
```

Invoking each of these delegates to accumulate the value seemed really ugly:
```cs
foreach (Delegate del in OnDamageTaken.GetInvocationList())
{
    damage = ((Func<float, float>)del)(damage);
}
```

Let me know what you think.

To demo, I have added a small white box in the MainScene. When you touch it, it will create an instance of the Courage buff, apply it, and remove it after 20 seconds according to the DebugBuffProvider.cs
