### PR TITLE
implemented harpoon tweaks

### DIFF
--- a/Assets/Prefabs/Weapons/HarpoonGun/HarpoonGun.prefab
+++ b/Assets/Prefabs/Weapons/HarpoonGun/HarpoonGun.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   harpoons: 3
   harpoonVelocity: 20
   harpoonSpearGravityScale: 1
-  harpoonSpearPickupCooldown: 0
+  harpoonSpearPickupCooldown: 1
   collectionRadius: 2
   harpoonTimer: 5
   spearReturnSpeed: 10

--- a/Assets/Prefabs/Weapons/HarpoonGun/HarpoonGun.prefab
+++ b/Assets/Prefabs/Weapons/HarpoonGun/HarpoonGun.prefab
@@ -62,6 +62,9 @@ MonoBehaviour:
   harpoonVelocity: 20
   harpoonSpearGravityScale: 1
   harpoonSpearPickupCooldown: 0
+  collectionRadius: 4
+  harpoonTimer: 5
+  spearReturnSpeed: 5
   harpoonSpearPrefab: {fileID: 3775420795739930932, guid: 3287e05fa4feefa43b2d14e7d0d7e6de, type: 3}
 --- !u!1 &7395887500203567774
 GameObject:

--- a/Assets/Prefabs/Weapons/HarpoonGun/HarpoonGun.prefab
+++ b/Assets/Prefabs/Weapons/HarpoonGun/HarpoonGun.prefab
@@ -62,9 +62,9 @@ MonoBehaviour:
   harpoonVelocity: 20
   harpoonSpearGravityScale: 1
   harpoonSpearPickupCooldown: 0
-  collectionRadius: 4
+  collectionRadius: 2
   harpoonTimer: 5
-  spearReturnSpeed: 5
+  spearReturnSpeed: 10
   harpoonSpearPrefab: {fileID: 3775420795739930932, guid: 3287e05fa4feefa43b2d14e7d0d7e6de, type: 3}
 --- !u!1 &7395887500203567774
 GameObject:

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1834,6 +1834,10 @@ PrefabInstance:
       propertyPath: debugPullToTargetTransform
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 8474927021672394680, guid: a0a8f7069068e40faa87eaf58c7b7cda, type: 3}
+      propertyPath: spearReturnSpeed
+      value: 10
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 2686506879466193411, guid: a0a8f7069068e40faa87eaf58c7b7cda, type: 3}
     m_RemovedGameObjects:

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1834,10 +1834,6 @@ PrefabInstance:
       propertyPath: debugPullToTargetTransform
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 8474927021672394680, guid: a0a8f7069068e40faa87eaf58c7b7cda, type: 3}
-      propertyPath: spearReturnSpeed
-      value: 10
-      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 2686506879466193411, guid: a0a8f7069068e40faa87eaf58c7b7cda, type: 3}
     m_RemovedGameObjects:

--- a/Assets/Scripts/Players/Player.cs
+++ b/Assets/Scripts/Players/Player.cs
@@ -77,6 +77,8 @@ namespace Players {
 
         private IBehaviour behaviour;
 
+        public Vector3 Center => transform.position + new Vector3(0, 1, 0);
+
         public void Awake() {
             UseBehaviour(Idle.AdHoc(this));
         }

--- a/Assets/Scripts/Weapon/HarpoonGun/HarpoonGun.cs
+++ b/Assets/Scripts/Weapon/HarpoonGun/HarpoonGun.cs
@@ -14,6 +14,9 @@ public class HarpoonGun : WeaponClass
     [SerializeField] public float harpoonVelocity;
     [SerializeField] public float harpoonSpearGravityScale;
     [SerializeField] public float harpoonSpearPickupCooldown; // seconds
+    [SerializeField] public float collectionRadius;
+    [SerializeField] public float harpoonTimer; // seconds
+    [SerializeField] public float spearReturnSpeed;
 
     [Header("HarpoonGun References")]
     public GameObject harpoonSpearPrefab;
@@ -91,6 +94,14 @@ public class HarpoonGun : WeaponClass
     void Update()
     {
         HandleWeaponRotation();
+
+        foreach (var spear in firedSpears) {
+            if (spear.isCollectable() && 
+                    Vector2.Distance(player.transform.position, spear.transform.position) <= collectionRadius)
+            {
+                spear.ReturnToPlayer();
+            }
+        }
     }
 
     public void SpearCollected(HarpoonSpear spear) {

--- a/Assets/Scripts/Weapon/HarpoonGun/HarpoonGun.cs
+++ b/Assets/Scripts/Weapon/HarpoonGun/HarpoonGun.cs
@@ -28,7 +28,6 @@ public class HarpoonGun : WeaponClass
 
     private void Start()
     {
-        Debug.Log(damage);
         harpoonSpearPool = new ObjectPool<HarpoonSpear>(
             // Create
             () => {
@@ -51,6 +50,7 @@ public class HarpoonGun : WeaponClass
             harpoons,
             harpoons
         );
+        base.Start();
     }
 
     protected override void HandleAttack()
@@ -78,7 +78,7 @@ public class HarpoonGun : WeaponClass
             return;
         }
 
-        player.GetComponent<Player>().UsePull(target);
+        playerComponent.UsePull(target);
     }
 
 
@@ -96,8 +96,8 @@ public class HarpoonGun : WeaponClass
         HandleWeaponRotation();
 
         foreach (var spear in firedSpears) {
-            if (spear.isCollectable() && 
-                    Vector2.Distance(player.transform.position, spear.transform.position) <= collectionRadius)
+            if (spear.isCollectable() &&
+                    Vector2.Distance(playerComponent.Center, spear.transform.position) <= collectionRadius)
             {
                 spear.ReturnToPlayer();
             }
@@ -116,7 +116,7 @@ public class HarpoonGun : WeaponClass
     }
 
     private void HandleWeaponRotation() {
-        Vector2 facing = player.GetComponent<Player>().facing;
+        Vector2 facing = playerComponent.facing;
 
         float angle = Mathf.Atan2(facing.y, facing.x) * Mathf.Rad2Deg;
         transform.rotation = Quaternion.Euler(new Vector3(0, 0, angle));

--- a/Assets/Scripts/Weapon/HarpoonGun/HarpoonGun.cs
+++ b/Assets/Scripts/Weapon/HarpoonGun/HarpoonGun.cs
@@ -96,7 +96,7 @@ public class HarpoonGun : WeaponClass
         HandleWeaponRotation();
 
         foreach (var spear in firedSpears) {
-            if (spear.isCollectable() &&
+            if (spear.IsCollectable &&
                     Vector2.Distance(playerComponent.Center, spear.transform.position) <= collectionRadius)
             {
                 spear.ReturnToPlayer();

--- a/Assets/Scripts/Weapon/HarpoonGun/HarpoonSpear.cs
+++ b/Assets/Scripts/Weapon/HarpoonGun/HarpoonSpear.cs
@@ -32,6 +32,8 @@ public class HarpoonSpear : MonoBehaviour {
     public Enemy TaggedEnemy { get; private set; }
     public Transform PullTo { get; private set; }
 
+    public bool IsCollectable => collectable;
+
     public void Awake() {
         dropped = false;
         TaggedEnemy = null;
@@ -75,10 +77,6 @@ public class HarpoonSpear : MonoBehaviour {
 
     public void ReturnToPlayer() {
         playerAbsorb = true;
-    }
-
-    public bool isCollectable() {
-        return collectable;
     }
 
     public void Update() {

--- a/Assets/Scripts/Weapon/HarpoonGun/HarpoonSpear.cs
+++ b/Assets/Scripts/Weapon/HarpoonGun/HarpoonSpear.cs
@@ -90,7 +90,7 @@ public class HarpoonSpear : MonoBehaviour {
 
         if (playerAbsorb) {
             transform.position = Vector2
-                .MoveTowards(transform.position, player.transform.position, gun.spearReturnSpeed * Time.deltaTime);
+                .MoveTowards(transform.position, player.Center, gun.spearReturnSpeed * Time.deltaTime);
 
             // Rotate over Z axis to face away from Player
             Vector3 difference = transform.position - player.transform.position;

--- a/Assets/Scripts/Weapon/HarpoonGun/HarpoonSpear.cs
+++ b/Assets/Scripts/Weapon/HarpoonGun/HarpoonSpear.cs
@@ -91,7 +91,7 @@ public class HarpoonSpear : MonoBehaviour {
                 .MoveTowards(transform.position, player.Center, gun.spearReturnSpeed * Time.deltaTime);
 
             // Rotate over Z axis to face away from Player
-            Vector3 difference = transform.position - player.transform.position;
+            Vector3 difference = transform.position - player.Center;
             float rotationZ = Mathf.Atan2(difference.y, difference.x) * Mathf.Rad2Deg;
             transform.rotation = Quaternion.Euler(0.0f, 0.0f, rotationZ);
         }

--- a/Assets/Scripts/Weapon/WeaponClass.cs
+++ b/Assets/Scripts/Weapon/WeaponClass.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections;
+using Players;
 using UnityEngine;
 
 public abstract class WeaponClass : MonoBehaviour
@@ -15,6 +17,11 @@ public abstract class WeaponClass : MonoBehaviour
     public float damageToFlowRatio = 1; // determines the rate at which damage is translated into flow.
 
     private bool canAttack = true;
+    protected Player playerComponent;
+
+    public void Start() {
+        playerComponent = player.GetComponent<Player>();
+    }
 
     public void Attack() {
         if (!canAttack) {


### PR DESCRIPTION
26-john-harpoontweaks

1. Harpoon spears now float toward the player if they are within a certain radius
2. Harpoon spears now automatically return to the player if not collected after a certain time frame

- HarpoonGun now has 3 new [SerializeFields]:
	- collectionRadius: controls the radius at which the returning spear occurs
	- harpoonTimer: controls the amount of time needed before spear automatically returns
	- spearReturnSpeed: controls the speed at which spears float toward the player

- HarpoonSpear now has 2 new fields:
	- playerAbsorb: bool to check if spear has started returning to the player
	- absorbCooldown: used in BeginHarpoonTimer() method, similar usage to "cooldown" field
- Added new methods to HarpoonSpear:
	- ReturnToPlayer(): set playerAbsorb to true, HarpoonGun uses it to access this field
	- isCollectable(): checks if collectable field is set to true
	- StartHarpoonTimer() and BeginHarpoonTimer(): handle the harpoonTimer, similar usage to StartCooldown() and DropCooldown()

- How the absorb feature works:
	- On each Update() in HarpoonSpear, we check if playerAbsorb is set to true
	- position of spear's transform is updated to MoveTowards the player based on spearReturnSpeed
	- rotation of spear's transform is updated to face away from the player

- HarpoonGun Update() method updated to check for spear distance
	- we check each spear in "firedSpears" linkedlist
	- if a spear's distance to the player is less than collectionRadius, set that spear's playerAbsorb field to true

Minor changes in HarpoonSpear to implement the tweaks:
	- Awake() method now sets playerAbsorb to false
	- HandlePlayerCollision() sets playerAbsorb to false
	- HandleEnemyCollision, HandleSemisolidCollision, and HandleGroundCollision now run the StartHarpoonTimer method