### PR TITLE
[31] Implement Elite Armadillo and Shield

### DIFF
--- a/Assets/Prefabs/Enemies/Elite Armadillo Variant.prefab
+++ b/Assets/Prefabs/Enemies/Elite Armadillo Variant.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4548019387955610069
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157272981753954215, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5710193498280292276, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: m_Name
+      value: Elite Armadillo Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 6491317554158063245, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      propertyPath: hitDistance
+      value: 1.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5710193498280292276, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6150675602155955691}
+  m_SourcePrefab: {fileID: 100100000, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+--- !u!1 &8080409027652284001 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5710193498280292276, guid: 6f3a6004e073d451da5cfcfe0449ce25, type: 3}
+  m_PrefabInstance: {fileID: 4548019387955610069}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6150675602155955691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8080409027652284001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 739b32100e35e9d45bfa72c2749fc3ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxShieldHealth: 100
+  shieldHealth: 0

--- a/Assets/Prefabs/Enemies/Elite Armadillo Variant.prefab.meta
+++ b/Assets/Prefabs/Enemies/Elite Armadillo Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e62dd6acf483e8449b838c9dece327af
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI/EnemyUI.prefab
+++ b/Assets/Prefabs/UI/EnemyUI.prefab
@@ -31,6 +31,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4349903152598682903}
+  - {fileID: 5387610361037424179}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -76,7 +77,171 @@ MonoBehaviour:
   rect: {fileID: 364043463454939432}
   canvas: {fileID: 3902291127570449180}
   slider: {fileID: 639969238204844111}
+  shield: {fileID: 8687028763567826641}
   subject: {fileID: 0}
+--- !u!1 &1818459222707638797
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4950219297696819536}
+  - component: {fileID: 3854636976620634800}
+  - component: {fileID: 26306669501580980}
+  m_Layer: 0
+  m_Name: Graphics
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4950219297696819536
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1818459222707638797}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5387610361037424179}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3854636976620634800
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1818459222707638797}
+  m_CullTransparentMesh: 1
+--- !u!114 &26306669501580980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1818459222707638797}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.85490197, g: 0.64705884, b: 0.1254902, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3637475952353194178
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5387610361037424179}
+  - component: {fileID: 8687028763567826641}
+  m_Layer: 0
+  m_Name: Shield
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5387610361037424179
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3637475952353194178}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4950219297696819536}
+  m_Father: {fileID: 364043463454939432}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -10}
+  m_SizeDelta: {x: 25, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8687028763567826641
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3637475952353194178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 26306669501580980}
+  m_FillRect: {fileID: 4950219297696819536}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.5
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &8251853942600545892
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1336,6 +1336,11 @@ Transform:
   - {fileID: 2039889831}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &983758066 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+  m_PrefabInstance: {fileID: 8976293154258135387}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &994940126
 GameObject:
   m_ObjectHideFlags: 0
@@ -79923,6 +79928,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 722286561}
+  - {fileID: 983758066}
   - {fileID: 913447148}
   - {fileID: 946649888}
   m_Father: {fileID: 970156644}
@@ -80000,6 +80006,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 479226366710450298, guid: e1b6f14b31dd34031b237061b57e5101, type: 3}
   m_PrefabInstance: {fileID: 7343341171840520289}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8976293154258135387
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2127775288}
+    m_Modifications:
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.507
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2516918256012557938, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8080409027652284001, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
+      propertyPath: m_Name
+      value: Elite Armadillo
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e62dd6acf483e8449b838c9dece327af, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemies/Armadillo/Armadillo.cs
+++ b/Assets/Scripts/Enemies/Armadillo/Armadillo.cs
@@ -16,6 +16,7 @@ namespace Enemies.Armadillo {
         [SerializeField] internal LayerMask player;
         [SerializeField] internal BoxCollider2D[] checks;
         [SerializeField] internal Vector2 facing = Vector2.right;
+        [SerializeField] internal float hitDistance = 1;
 
         public void Awake() {
             UseBehaviour(new Walk(this));

--- a/Assets/Scripts/Enemies/Armadillo/Behaviour/Rush.cs
+++ b/Assets/Scripts/Enemies/Armadillo/Behaviour/Rush.cs
@@ -39,7 +39,7 @@ namespace Enemies.Armadillo.Behaviour {
         }
 
         private void UseStun() {
-            var hit = Enemy.Sweep(self.sprite.transform.position, self.facing, 0, 1, 1, self.player).First();
+            var hit = Enemy.Sweep(self.sprite.transform.position, self.facing, 0, self.hitDistance, 1, self.player).First();
             if (hit) self.Attack(hit.collider.gameObject);
 
             self.UseBehaviour(new Stun(self));

--- a/Assets/Scripts/Enemies/Shield.meta
+++ b/Assets/Scripts/Enemies/Shield.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f9aa9ab34956444e9d5db61793f3a16
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemies/Shield/Shield.cs
+++ b/Assets/Scripts/Enemies/Shield/Shield.cs
@@ -15,8 +15,16 @@ public class Shield : MonoBehaviour {
     }
 
     private float OnHit(float damage) {
-        if (shieldHealth <= 0) return damage;
+        if (shieldHealth <= 0) {
+            self.OnHurt -= OnHit;
+            return damage;
+        }
         shieldHealth = Mathf.Max(shieldHealth - damage, 0);
         return 0; // Prevent overflow
+    }
+
+    private void OnDestroy() {
+        if (self == null) return;
+        self.OnHurt -= OnHit;
     }
 }

--- a/Assets/Scripts/Enemies/Shield/Shield.cs
+++ b/Assets/Scripts/Enemies/Shield/Shield.cs
@@ -1,0 +1,22 @@
+using Enemies;
+using UnityEngine;
+
+[RequireComponent(typeof(Enemy))]
+public class Shield : MonoBehaviour {
+    [SerializeField] internal float maxShieldHealth;
+    [SerializeField] internal float shieldHealth;
+    private Enemy self;
+
+    // Start is called before the first frame update
+    private void Start() {
+        shieldHealth = maxShieldHealth;
+        self = GetComponent<Enemy>();
+        self.OnHurt += OnHit;
+    }
+
+    private float OnHit(float damage) {
+        if (shieldHealth <= 0) return damage;
+        shieldHealth = Mathf.Max(shieldHealth - damage, 0);
+        return 0; // Prevent overflow
+    }
+}

--- a/Assets/Scripts/Enemies/Shield/Shield.cs.meta
+++ b/Assets/Scripts/Enemies/Shield/Shield.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 739b32100e35e9d45bfa72c2749fc3ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/EnemyUI.cs
+++ b/Assets/Scripts/UI/EnemyUI.cs
@@ -1,4 +1,5 @@
 using Enemies;
+using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -7,11 +8,19 @@ namespace UI {
         [SerializeField] internal RectTransform rect;
         [SerializeField] internal Canvas canvas;
         [SerializeField] internal Slider slider;
-
+        [SerializeField] internal Slider shield;
         [SerializeField] internal Enemy subject;
+
+        private Shield enemyShield;
+
+        public void Start() {
+            enemyShield = subject.GetComponent<Shield>();
+            shield.gameObject.SetActive(enemyShield != null);
+        }
 
         public void Update() {
             slider.value = subject.maximumHealth == 0 ? 0 : subject.currentHealth / subject.maximumHealth;
+            UpdateShield();
         }
 
         public EnemyUI Of(Enemy e) {
@@ -27,6 +36,11 @@ namespace UI {
             var p = c.WorldToViewportPoint(position);
             var d = 2 * canvas.scaleFactor;
             return new Vector2(c.pixelWidth * (p.x * 2 - 1) / d, c.pixelHeight * (p.y * 2 - 1) / d);
+        }
+
+        private void UpdateShield() {
+            if (enemyShield == null) return;
+            shield.value = enemyShield.maxShieldHealth == 0 ? 0 : enemyShield.shieldHealth / enemyShield.maxShieldHealth;
         }
     }
 }

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -48,7 +48,8 @@ namespace UI {
 
         private void OnEnemySpawn(Enemy enemy) {
             var ui = prefabs[0];
-            enemies[enemy] = Instantiate(ui, canvas.transform).GetComponent<EnemyUI>()!.Of(enemy);
+            var prefab = Instantiate(ui, canvas.transform).GetComponent<EnemyUI>()!.Of(enemy);
+            enemies[enemy] = prefab;
         }
 
         private void InitializePlayerUI() {


### PR DESCRIPTION
Notes:
- I opted not to implement a base EliteEnemy class at all. Instead, I think its better to design by composition. Any enemy can have a shield, but if we want it to be the case that only elite enemies have shields, then simply create a prefab variant of that enemy and attach a shield component to it
- If an elite variant of an enemy needs new / custom behaviour, then that behaviour should be implemented on its own according to its needs (either a new class, a subclass, or something in between)

Let me know if you don't like this solution, but I think it's a lot cleaner than utilising inheritance, since inheritance will inevitably force code duplication and creates a messy hierarchy of abstractions.