### PR TITLE
Update HUD on player respawn

### DIFF
--- a/Assets/Scripts/Players/Player.cs
+++ b/Assets/Scripts/Players/Player.cs
@@ -150,6 +150,7 @@ namespace Players {
 
             // initially fill out the skill bar
             OnSkillCooldownUpdated?.Invoke(1);
+            OnWeaponChanged?.Invoke(0);
             Spawn?.Invoke();
         }
 
@@ -193,7 +194,7 @@ namespace Players {
             }
 
             combatTimer.Start();
-            CurrentHealth -= (int) damage; 
+            CurrentHealth -= (int) damage;
             currentHurtInvulnerability = hurtInvulnerabilityTime;
             UseExternalVelocity(velocity, lockout);
             StartCoroutine(DoHurtInvincibilityFlicker());


### PR DESCRIPTION
#115. I wasn't actually able to get the ammo capacities to be different, but I did have a bug where if the player last had the shotgun equipped, the shotgun sprite would stay on the HUD. This PR fixes it by calling the weapon change event on the Player's Start().